### PR TITLE
Don't bundle test dependencies in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ EXPOSE 9292
 
 ADD . /var/app/fleet-adapter
 WORKDIR /var/app/fleet-adapter
-RUN bundle install
+RUN bundle install --without development test
 
 CMD ["rackup", "-E production"]


### PR DESCRIPTION
The Dockerfiles in the other apps do this, and I just noticed while I was building this locally.
